### PR TITLE
feat: add public library preview and normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 chroma_db/
 .DS_Store
+preview_outputs/

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ python pipeline.py
 python check_db.py
 ```
 
+### 전국도서관표준데이터 미리보기 수집
+
+```bash
+python preview_public_libraries.py --pages 1 --num-rows 100
+```
+
+- 결과는 기본적으로 `preview_outputs/public_libraries_preview.json` 에 저장됩니다.
+- DB/Chroma 저장 없이 원본 API 응답 기반으로 데이터 품질을 점검할 때 사용합니다.
+- 예시 필터:
+
+```bash
+python preview_public_libraries.py --ctprvn 경기도 --sigungu 남양주시 --pages 1 --num-rows 50
+```
+
 ### DB 뷰어 (Streamlit)
 
 ```bash

--- a/collectors/public_library.py
+++ b/collectors/public_library.py
@@ -1,0 +1,106 @@
+import logging
+from typing import Any
+
+from collectors.base import BaseCollector
+
+logger = logging.getLogger(__name__)
+
+PUBLIC_LIBRARY_API_URL = "https://api.data.go.kr/openapi/tn_pubr_public_lbrry_api"
+MAX_NUM_OF_ROWS = 1000
+
+
+class PublicLibraryCollector(BaseCollector):
+    PLATFORM = "전국도서관표준데이터"
+
+    def collect_all(self):
+        raise NotImplementedError("검증 단계에서는 fetch_page() 기반으로만 사용합니다.")
+
+    def build_params(
+        self,
+        page_no: int = 1,
+        num_of_rows: int = 100,
+        filters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "serviceKey": self.api_key,
+            "pageNo": page_no,
+            "numOfRows": max(1, min(num_of_rows, MAX_NUM_OF_ROWS)),
+            "type": "json",
+        }
+
+        for key, value in (filters or {}).items():
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            params[key] = value
+
+        return params
+
+    def fetch_page(
+        self,
+        page_no: int = 1,
+        num_of_rows: int = 100,
+        filters: dict[str, Any] | None = None,
+        debug: bool = False,
+    ) -> dict[str, Any]:
+        params = self.build_params(page_no=page_no, num_of_rows=num_of_rows, filters=filters)
+        payload = self.fetch(PUBLIC_LIBRARY_API_URL, params=params, debug=debug)
+        if not payload:
+            raise RuntimeError("응답이 비어 있습니다.")
+
+        response = payload.get("response", {})
+        header = response.get("header", {})
+        body = response.get("body", {})
+
+        result_code = str(header.get("resultCode", "")).zfill(2)
+        result_msg = header.get("resultMsg", "")
+
+        if result_code not in {"00", "03"}:
+            raise RuntimeError(f"API 오류: {result_code} {result_msg}")
+
+        items = self._extract_items(body.get("items"))
+        total_count = self._safe_int(body.get("totalCount"))
+
+        logger.info(
+            "[%s] page=%s fetched=%s total=%s code=%s",
+            self.PLATFORM,
+            page_no,
+            len(items),
+            total_count,
+            result_code,
+        )
+
+        return {
+            "resultCode": result_code,
+            "resultMsg": result_msg,
+            "pageNo": self._safe_int(body.get("pageNo"), page_no),
+            "numOfRows": self._safe_int(body.get("numOfRows"), num_of_rows),
+            "totalCount": total_count,
+            "items": items,
+        }
+
+    @staticmethod
+    def _extract_items(raw_items: Any) -> list[dict[str, Any]]:
+        if raw_items is None:
+            return []
+
+        if isinstance(raw_items, list):
+            return [item for item in raw_items if isinstance(item, dict)]
+
+        if isinstance(raw_items, dict):
+            nested = raw_items.get("item")
+            if isinstance(nested, list):
+                return [item for item in nested if isinstance(item, dict)]
+            if isinstance(nested, dict):
+                return [nested]
+            return [raw_items]
+
+        return []
+
+    @staticmethod
+    def _safe_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default

--- a/preview_public_libraries.py
+++ b/preview_public_libraries.py
@@ -1,0 +1,126 @@
+import argparse
+import json
+import logging
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+from collectors.public_library import PublicLibraryCollector
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT = Path("preview_outputs/public_libraries_preview.json")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="전국도서관표준데이터 미리보기 수집")
+    parser.add_argument("--page-start", type=int, default=1, help="시작 페이지 번호")
+    parser.add_argument("--pages", type=int, default=1, help="수집할 페이지 수")
+    parser.add_argument("--num-rows", type=int, default=100, help="페이지당 건수 (최대 1000)")
+    parser.add_argument("--ctprvn", default="", help="시도명 필터")
+    parser.add_argument("--sigungu", default="", help="시군구명 필터")
+    parser.add_argument("--library-type", default="", help="도서관유형 필터")
+    parser.add_argument("--library-name", default="", help="도서관명 필터")
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="미리보기 JSON 저장 경로")
+    return parser.parse_args()
+
+
+def build_filters(args: argparse.Namespace) -> dict[str, str]:
+    return {
+        "CTPRVN_NM": args.ctprvn,
+        "SIGNGU_NM": args.sigungu,
+        "LBRRY_SE": args.library_type,
+        "LBRRY_NM": args.library_name,
+    }
+
+
+def summarize_items(items: list[dict[str, Any]]) -> dict[str, Any]:
+    library_types = Counter(item.get("LBRRY_SE") or "미상" for item in items)
+    provinces = Counter(item.get("CTPRVN_NM") or "미상" for item in items)
+
+    return {
+        "itemsFetched": len(items),
+        "missingCoordinates": sum(
+            1 for item in items if not item.get("LATITUDE") or not item.get("LONGITUDE")
+        ),
+        "missingRoadAddress": sum(1 for item in items if not item.get("RDNMADR")),
+        "missingPhoneNumber": sum(1 for item in items if not item.get("PHONE_NUMBER")),
+        "missingHomepageUrl": sum(1 for item in items if not item.get("HOMEPAGE_URL")),
+        "missingOperatingHours": sum(
+            1
+            for item in items
+            if not item.get("WEEKDAY_OPER_OPEN_HHMM") or not item.get("WEEKDAY_OPER_COLSE_HHMM")
+        ),
+        "libraryTypes": dict(library_types.most_common()),
+        "provinces": dict(provinces.most_common()),
+    }
+
+
+def main() -> None:
+    load_dotenv()
+    api_key = os.getenv("DATA_GO_KR_API_KEY", "")
+    if not api_key:
+        raise SystemExit("DATA_GO_KR_API_KEY 환경 변수가 필요합니다.")
+
+    args = parse_args()
+    filters = build_filters(args)
+    collector = PublicLibraryCollector(api_key=api_key)
+
+    all_items: list[dict[str, Any]] = []
+    total_count = 0
+    pages_fetched = 0
+
+    for offset in range(args.pages):
+        page_no = args.page_start + offset
+        page = collector.fetch_page(
+            page_no=page_no,
+            num_of_rows=args.num_rows,
+            filters=filters,
+            debug=(offset == 0),
+        )
+
+        pages_fetched += 1
+        total_count = page["totalCount"] or total_count
+        all_items.extend(page["items"])
+
+        if not page["items"]:
+            logger.info("빈 페이지를 받아 수집을 종료합니다. page=%s", page_no)
+            break
+
+        expected_count = page["pageNo"] * page["numOfRows"]
+        if total_count and expected_count >= total_count:
+            break
+
+        collector.delay()
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "source": "전국도서관표준데이터",
+        "fetchedAt": datetime.now(timezone.utc).astimezone().isoformat(),
+        "request": {
+            "pageStart": args.page_start,
+            "pages": args.pages,
+            "numOfRows": args.num_rows,
+            "filters": {key: value for key, value in filters.items() if value},
+        },
+        "summary": {
+            "pagesFetched": pages_fetched,
+            "totalCountFromApi": total_count,
+            **summarize_items(all_items),
+        },
+        "items": all_items,
+    }
+
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    logger.info("미리보기 JSON 저장 완료: %s", output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/preview_public_libraries.py
+++ b/preview_public_libraries.py
@@ -17,6 +17,87 @@ logger = logging.getLogger(__name__)
 DEFAULT_OUTPUT = Path("preview_outputs/public_libraries_preview.json")
 
 
+def pick(item: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in item and item[key] not in (None, ""):
+            return item[key]
+    return None
+
+
+def parse_int(value: Any) -> int | None:
+    try:
+        if value in (None, ""):
+            return None
+        return int(str(value).replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_float(value: Any) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def format_operating_hours(item: dict[str, Any]) -> str:
+    close_day = pick(item, "closeDay", "CLOSE_DAY") or "정보 없음"
+
+    def time_range(open_key: str, close_key: str, label: str) -> str:
+        open_time = pick(item, open_key)
+        close_time = pick(item, close_key)
+        if not open_time or not close_time or (open_time == "00:00" and close_time == "00:00"):
+            return f"{label} 운영안함"
+        return f"{label} {open_time}~{close_time}"
+
+    parts = [f"휴관일: {close_day}"]
+    parts.append(time_range("weekdayOperOpenHhmm", "weekdayOperColseHhmm", "평일"))
+    parts.append(time_range("satOperOperOpenHhmm", "satOperCloseHhmm", "토요일"))
+    parts.append(time_range("holidayOperOpenHhmm", "holidayCloseOpenHhmm", "공휴일"))
+    return " / ".join(parts)
+
+
+def normalize_library_item(item: dict[str, Any]) -> dict[str, Any]:
+    name = pick(item, "lbrryNm", "LBRRY_NM")
+    address = pick(item, "rdnmadr", "RDNMADR")
+    latitude = parse_float(pick(item, "latitude", "LATITUDE"))
+    longitude = parse_float(pick(item, "longitude", "LONGITUDE"))
+
+    validation_issues = []
+    if not name:
+        validation_issues.append("missing_name")
+    if not address:
+        validation_issues.append("missing_address")
+    if latitude is None:
+        validation_issues.append("missing_latitude")
+    if longitude is None:
+        validation_issues.append("missing_longitude")
+
+    return {
+        "name": name,
+        "type": "LIBRARY",
+        "libraryType": pick(item, "lbrrySe", "LBRRY_SE"),
+        "address": address,
+        "latitude": latitude,
+        "longitude": longitude,
+        "phone": pick(item, "phoneNumber", "PHONE_NUMBER"),
+        "operatingHours": format_operating_hours(item),
+        "homepageUrl": pick(item, "homepageUrl", "HOMEPAGE_URL"),
+        "seatCount": parse_int(pick(item, "seatCo", "SEAT_CO")),
+        "operatorInstitution": pick(item, "operInstitutionNm", "OPER_INSTITUTION_NM"),
+        "province": pick(item, "ctprvnNm", "CTPRVN_NM"),
+        "city": pick(item, "signguNm", "SIGNGU_NM"),
+        "closeDay": pick(item, "closeDay", "CLOSE_DAY"),
+        "referenceDate": pick(item, "referenceDate", "REFERENCE_DATE"),
+        "sourceInstitutionCode": pick(item, "insttCode", "instt_code"),
+        "sourceInstitutionName": pick(item, "insttNm", "instt_nm"),
+        "isUsableForStudySpace": len(validation_issues) == 0,
+        "validationIssues": validation_issues,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="전국도서관표준데이터 미리보기 수집")
     parser.add_argument("--page-start", type=int, default=1, help="시작 페이지 번호")
@@ -40,22 +121,30 @@ def build_filters(args: argparse.Namespace) -> dict[str, str]:
 
 
 def summarize_items(items: list[dict[str, Any]]) -> dict[str, Any]:
-    library_types = Counter(item.get("LBRRY_SE") or "미상" for item in items)
-    provinces = Counter(item.get("CTPRVN_NM") or "미상" for item in items)
+    normalized_items = [normalize_library_item(item) for item in items]
+    library_types = Counter(pick(item, "lbrrySe", "LBRRY_SE") or "미상" for item in items)
+    provinces = Counter(pick(item, "ctprvnNm", "CTPRVN_NM") or "미상" for item in items)
+    validation_issue_counts = Counter(
+        issue
+        for item in normalized_items
+        for issue in item["validationIssues"]
+    )
 
     return {
         "itemsFetched": len(items),
         "missingCoordinates": sum(
-            1 for item in items if not item.get("LATITUDE") or not item.get("LONGITUDE")
-        ),
-        "missingRoadAddress": sum(1 for item in items if not item.get("RDNMADR")),
-        "missingPhoneNumber": sum(1 for item in items if not item.get("PHONE_NUMBER")),
-        "missingHomepageUrl": sum(1 for item in items if not item.get("HOMEPAGE_URL")),
-        "missingOperatingHours": sum(
             1
-            for item in items
-            if not item.get("WEEKDAY_OPER_OPEN_HHMM") or not item.get("WEEKDAY_OPER_COLSE_HHMM")
+            for item in normalized_items
+            if item["latitude"] is None or item["longitude"] is None
         ),
+        "missingRoadAddress": sum(1 for item in normalized_items if not item["address"]),
+        "missingPhoneNumber": sum(1 for item in normalized_items if not item["phone"]),
+        "missingHomepageUrl": sum(1 for item in normalized_items if not item["homepageUrl"]),
+        "missingOperatingHours": sum(
+            1 for item in normalized_items if "정보 없음" in item["operatingHours"]
+        ),
+        "usableForStudySpaces": sum(1 for item in normalized_items if item["isUsableForStudySpace"]),
+        "validationIssueCounts": dict(validation_issue_counts),
         "libraryTypes": dict(library_types.most_common()),
         "provinces": dict(provinces.most_common()),
     }
@@ -100,6 +189,7 @@ def main() -> None:
 
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    normalized_items = [normalize_library_item(item) for item in all_items]
 
     payload = {
         "source": "전국도서관표준데이터",
@@ -115,6 +205,24 @@ def main() -> None:
             "totalCountFromApi": total_count,
             **summarize_items(all_items),
         },
+        "selectedFields": [
+            "name",
+            "type",
+            "libraryType",
+            "address",
+            "latitude",
+            "longitude",
+            "phone",
+            "operatingHours",
+            "homepageUrl",
+            "seatCount",
+            "operatorInstitution",
+            "province",
+            "city",
+            "closeDay",
+            "referenceDate",
+        ],
+        "studySpaceCandidates": normalized_items,
         "items": all_items,
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests==2.31.0
 chromadb>=0.5.0
 sentence-transformers==2.6.1
-python-dotenv==1.0.0fastapi>=0.110.0
+python-dotenv==1.0.0
+fastapi>=0.110.0
 uvicorn[standard]>=0.29.0


### PR DESCRIPTION
## Summary
- add a preview crawler for the 전국도서관표준데이터 API without persisting records
- normalize library API responses into study-space candidate fields for place recommendation
- include summary stats to validate address, coordinates, hours, and other required fields before ingestion