### PR TITLE
공공도서관과 청년센터 적재 파이프라인을 정비

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,56 @@ MYSQL_DATABASE=kuriq
 실행 예시:
 
 ```bash
-.venv/bin/python load_public_libraries_to_mysql.py --pages 5 --num-rows 100
+.venv/bin/python load_public_libraries_to_mysql.py
 ```
 
 - 장소추천 MVP에 필요한 필드만 사용합니다: 이름, 타입, 주소, 좌표, 운영시간, 전화번호
 - `name + address + type` 기준으로 기존 레코드가 있으면 update, 없으면 insert 합니다.
+- 기본값은 `num_rows=300`, `pages=0(전체 적재)` 이므로 전국 데이터를 안정적으로 끝까지 가져옵니다.
+- 공공데이터 API 응답이 느릴 수 있어 수집기 기본 read timeout도 늘려두었습니다.
+- 테스트/샘플 적재가 필요하면 명시적으로 페이지 수를 제한하세요.
+
+대량 적재를 더 빠르게 돌리고 싶으면:
+
+```bash
+COLLECTOR_READ_TIMEOUT=90 .venv/bin/python load_public_libraries_to_mysql.py --num-rows 1000
+```
+
+### 청년센터 공간 정보를 MySQL `study_spaces`에 적재
+
+`.env`에 청년센터 API 키와 카카오 로컬 API 키를 추가합니다.
+
+```env
+YOUTHCENTER_API_KEY=your-youthcenter-api-key
+KAKAO_LOCAL_REST_API_KEY=your-kakao-local-rest-api-key
+```
+
+기본 실행 예시:
+
+```bash
+.venv/bin/python load_youth_centers_to_mysql.py
+```
+
+- 청년센터 API는 좌표를 주지 않으므로 주소를 카카오 로컬 API로 좌표 변환 후 `study_spaces`에 적재합니다.
+- 적재 타입은 `YOUTH_CENTER` 입니다.
+
+서울만 적재 예시:
+
+```bash
+.venv/bin/python load_youth_centers_to_mysql.py --ctpv-cd 11
+```
+
+샘플 적재 예시:
+
+```bash
+.venv/bin/python load_public_libraries_to_mysql.py --pages 1 --num-rows 100
+```
+
+서울만 적재 예시:
+
+```bash
+.venv/bin/python load_public_libraries_to_mysql.py --ctprvn 서울특별시
+```
 
 ### DB 뷰어 (Streamlit)
 

--- a/collectors/base.py
+++ b/collectors/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Generator
 from models.course import Course
 import logging
+import os
 import time
 import requests
 
@@ -13,11 +14,15 @@ class BaseCollector(ABC):
 
     PLATFORM: str = ""  
     REQUEST_DELAY: float = 0.3  # API 호출 간격 
+    CONNECT_TIMEOUT: float = 10.0
+    READ_TIMEOUT: float = 60.0
 
     def __init__(self, api_key: str = ""):
         self.api_key = api_key
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": "KuriqDataPipeline/1.0"})
+        self.connect_timeout = float(os.getenv("COLLECTOR_CONNECT_TIMEOUT", self.CONNECT_TIMEOUT))
+        self.read_timeout = float(os.getenv("COLLECTOR_READ_TIMEOUT", self.READ_TIMEOUT))
 
     @abstractmethod
     def collect_all(self) -> Generator[Course, None, None]:
@@ -27,8 +32,13 @@ class BaseCollector(ABC):
     def fetch(self, url: str, params: dict = None, retries: int = 3, debug: bool = False) -> dict:
         """공통 HTTP GET 요청 — 재시도 로직 포함"""
         for attempt in range(retries):
+            response = None
             try:
-                response = self.session.get(url, params=params, timeout=10)
+                response = self.session.get(
+                    url,
+                    params=params,
+                    timeout=(self.connect_timeout, self.read_timeout),
+                )
                 response.raise_for_status()
 
                 if debug:
@@ -41,16 +51,37 @@ class BaseCollector(ABC):
 
                 return response.json()
             except requests.exceptions.Timeout:
-                logger.warning(f"[{self.PLATFORM}] 타임아웃 (시도 {attempt + 1}/{retries}): {url}")
+                logger.warning(
+                    f"[{self.PLATFORM}] 타임아웃 (시도 {attempt + 1}/{retries}): {url} "
+                    f"(connect={self.connect_timeout}s, read={self.read_timeout}s)"
+                )
             except requests.exceptions.HTTPError as e:
-                logger.error(f"[{self.PLATFORM}] HTTP 오류 {e.response.status_code}: {url}")
-                logger.error(f"[{self.PLATFORM}] 응답 본문: {e.response.text[:500]}")
-                break
+                status_code = e.response.status_code
+                body_preview = e.response.text[:500]
+                if status_code >= 500 or status_code == 429:
+                    logger.warning(
+                        f"[{self.PLATFORM}] 재시도 가능한 HTTP 오류 {status_code} "
+                        f"(시도 {attempt + 1}/{retries}): {url}"
+                    )
+                    logger.warning(f"[{self.PLATFORM}] 응답 본문: {body_preview}")
+                else:
+                    logger.error(f"[{self.PLATFORM}] HTTP 오류 {status_code}: {url}")
+                    logger.error(f"[{self.PLATFORM}] 응답 본문: {body_preview}")
+                    break
+            except ValueError:
+                if response is not None:
+                    logger.warning(
+                        f"[{self.PLATFORM}] JSON 파싱 실패 (시도 {attempt + 1}/{retries}): {url}"
+                    )
+                    logger.warning(f"[{self.PLATFORM}] 응답 본문: {response.text[:500]}")
+                else:
+                    logger.warning(f"[{self.PLATFORM}] JSON 파싱 실패 (시도 {attempt + 1}/{retries}): {url}")
             except Exception as e:
                 logger.error(f"[{self.PLATFORM}] 요청 실패: {e}")
-                logger.error(f"[{self.PLATFORM}] RAW TEXT:\n{response.text[:1000]}")
+                if response is not None:
+                    logger.error(f"[{self.PLATFORM}] RAW TEXT:\n{response.text[:1000]}")
                 break
-            time.sleep(1)
+            time.sleep(min(2 ** attempt, 5))
         return {}
 
     def fetch_post(self, url: str, data: dict = None, headers: dict = None, retries: int = 3, debug: bool = False) -> str:

--- a/collectors/youth_center.py
+++ b/collectors/youth_center.py
@@ -1,0 +1,109 @@
+import logging
+from typing import Any
+
+from collectors.base import BaseCollector
+
+logger = logging.getLogger(__name__)
+
+YOUTH_CENTER_API_URL = "https://www.youthcenter.go.kr/go/ythip/getSpace"
+
+
+class YouthCenterCollector(BaseCollector):
+    PLATFORM = "청년센터"
+
+    def __init__(self, api_key: str = ""):
+        super().__init__(api_key=api_key)
+        self.session.headers.update(
+            {
+                "Accept": "application/json, text/plain, */*",
+                "Referer": "https://www.youthcenter.go.kr/",
+                "X-Requested-With": "XMLHttpRequest",
+            }
+        )
+
+    def collect_all(self):
+        raise NotImplementedError("검증 단계에서는 fetch_page() 기반으로만 사용합니다.")
+
+    def build_params(
+        self,
+        page_num: int = 1,
+        page_size: int = 100,
+        page_type: int | None = None,
+        filters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "apiKeyNm": self.api_key,
+            "pageNum": max(1, page_num),
+            "pageSize": max(1, page_size),
+            "rtnType": "json",
+        }
+        if page_type is not None:
+            params["pageType"] = page_type
+
+        for key, value in (filters or {}).items():
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            params[key] = value
+
+        return params
+
+    def fetch_page(
+        self,
+        page_num: int = 1,
+        page_size: int = 100,
+        page_type: int | None = None,
+        filters: dict[str, Any] | None = None,
+        debug: bool = False,
+    ) -> dict[str, Any]:
+        params = self.build_params(
+            page_num=page_num,
+            page_size=page_size,
+            page_type=page_type,
+            filters=filters,
+        )
+        payload = self.fetch(YOUTH_CENTER_API_URL, params=params, retries=5, debug=debug)
+        if not payload:
+            raise RuntimeError("응답이 비어 있습니다.")
+
+        result_code = int(payload.get("resultCode", 0) or 0)
+        result_message = payload.get("resultMessage", "")
+        if result_code != 200:
+            raise RuntimeError(f"API 오류: {result_code} {result_message}")
+
+        result = payload.get("result") or {}
+        paging = result.get("pagging") or {}
+        items = result.get("youthPolicyList") or []
+
+        if not isinstance(items, list):
+            items = []
+
+        total_count = self._safe_int(paging.get("totCount"))
+        normalized_page_num = self._safe_int(paging.get("pageNum"), page_num)
+        normalized_page_size = self._safe_int(paging.get("pageSize"), page_size)
+
+        logger.info(
+            "[%s] page=%s fetched=%s total=%s code=%s",
+            self.PLATFORM,
+            normalized_page_num,
+            len(items),
+            total_count,
+            result_code,
+        )
+
+        return {
+            "resultCode": result_code,
+            "resultMessage": result_message,
+            "pageNum": normalized_page_num,
+            "pageSize": normalized_page_size,
+            "totalCount": total_count,
+            "items": [item for item in items if isinstance(item, dict)],
+        }
+
+    @staticmethod
+    def _safe_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default

--- a/load_youth_centers_to_mysql.py
+++ b/load_youth_centers_to_mysql.py
@@ -1,48 +1,57 @@
 import argparse
 import logging
 import os
+import re
 import uuid
 
 import pymysql
 from dotenv import load_dotenv
 
-from collectors.public_library import PublicLibraryCollector
+from collectors.youth_center import YouthCenterCollector
+from space_geocoders import KakaoLocalGeocoder
 from space_models import StudySpaceRecord
-from space_normalizers import normalize_public_library_to_study_space
+from space_normalizers import normalize_youth_center_to_study_space
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
+YOUTH_CENTER_TYPE = "YOUTH_CENTER"
+
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="전국도서관표준데이터를 study_spaces에 적재")
+    parser = argparse.ArgumentParser(description="청년센터 공간 정보를 study_spaces에 적재")
     parser.add_argument("--page-start", type=int, default=1, help="시작 페이지 번호")
-    parser.add_argument(
-        "--pages",
-        type=int,
-        default=0,
-        help="수집할 페이지 수. 0이면 마지막 페이지까지 전체 적재",
-    )
-    parser.add_argument(
-        "--num-rows",
-        type=int,
-        default=300,
-        help="페이지당 건수 (최대 1000). 운영 적재는 300~1000 권장",
-    )
-    parser.add_argument("--ctprvn", default="", help="시도명 필터")
-    parser.add_argument("--sigungu", default="", help="시군구명 필터")
-    parser.add_argument("--library-type", default="", help="도서관유형 필터")
-    parser.add_argument("--library-name", default="", help="도서관명 필터")
+    parser.add_argument("--pages", type=int, default=0, help="수집할 페이지 수. 0이면 전체 적재")
+    parser.add_argument("--page-size", type=int, default=100, help="페이지당 건수")
+    parser.add_argument("--page-type", type=int, default=None, help="화면유형")
+    parser.add_argument("--ctpv-cd", default="", help="시도코드")
+    parser.add_argument("--sgg-cd", default="", help="시군구코드")
+    parser.add_argument("--plc-sn", default="", help="센터일련번호")
+    parser.add_argument("--plc-type", default="", help="센터유형")
+    parser.add_argument("--api-key", default="", help="청년센터 API 키 (없으면 env 사용)")
+    parser.add_argument("--kakao-api-key", default="", help="카카오 로컬 REST API 키 (없으면 env 사용)")
     return parser.parse_args()
+
+
+def resolve_api_key(args: argparse.Namespace) -> str:
+    return args.api_key or os.getenv("YOUTHCENTER_API_KEY", "") or os.getenv("YOUTH_CENTER_API_KEY", "")
 
 
 def build_filters(args: argparse.Namespace) -> dict[str, str]:
     return {
-        "CTPRVN_NM": args.ctprvn,
-        "SIGNGU_NM": args.sigungu,
-        "LBRRY_SE": args.library_type,
-        "LBRRY_NM": args.library_name,
+        "ctpvCd": args.ctpv_cd,
+        "sggCd": args.sgg_cd,
+        "plcSn": args.plc_sn,
+        "plcType": args.plc_type,
     }
+
+
+def build_center_address(item: dict) -> str:
+    parts = [
+        (item.get("cntrAddr") or "").strip(),
+        (item.get("cntrDaddr") or "").strip(),
+    ]
+    return " ".join(part for part in parts if part)
 
 
 def connect_mysql():
@@ -56,6 +65,29 @@ def connect_mysql():
         cursorclass=pymysql.cursors.DictCursor,
         autocommit=False,
     )
+
+
+def ensure_study_space_type_enum(cursor, required_type: str) -> None:
+    cursor.execute("SHOW COLUMNS FROM study_spaces LIKE 'type'")
+    column = cursor.fetchone()
+    if not column:
+        raise RuntimeError("study_spaces.type 컬럼을 찾을 수 없습니다.")
+
+    type_definition = column["Type"]
+    enum_values = re.findall(r"'([^']+)'", type_definition)
+    if required_type in enum_values:
+        return
+
+    if "CAFE" in enum_values:
+        cafe_index = enum_values.index("CAFE")
+        enum_values.insert(cafe_index, required_type)
+    else:
+        enum_values.append(required_type)
+
+    enum_sql = ", ".join(f"'{value}'" for value in enum_values)
+    alter_sql = f"ALTER TABLE study_spaces MODIFY COLUMN type ENUM({enum_sql}) NOT NULL"
+    logger.info("study_spaces.type enum 확장: %s 추가", required_type)
+    cursor.execute(alter_sql)
 
 
 def upsert_study_space(cursor, record: StudySpaceRecord) -> str:
@@ -136,55 +168,80 @@ def upsert_study_space(cursor, record: StudySpaceRecord) -> str:
 
 def main() -> None:
     load_dotenv()
-    api_key = os.getenv("DATA_GO_KR_API_KEY", "")
-    if not api_key:
-        raise SystemExit("DATA_GO_KR_API_KEY 환경 변수가 필요합니다.")
-
     args = parse_args()
+
+    api_key = resolve_api_key(args)
+    if not api_key:
+        raise SystemExit("YOUTHCENTER_API_KEY 또는 YOUTH_CENTER_API_KEY 환경 변수가 필요합니다.")
     if args.page_start < 1:
         raise SystemExit("--page-start 는 1 이상이어야 합니다.")
     if args.pages < 0:
         raise SystemExit("--pages 는 0 이상이어야 합니다. 0은 전체 적재입니다.")
 
     filters = build_filters(args)
-    collector = PublicLibraryCollector(api_key=api_key)
+    collector = YouthCenterCollector(api_key=api_key)
+    geocoder = KakaoLocalGeocoder(api_key=args.kakao_api_key or None)
+    if not geocoder.api_key:
+        raise SystemExit("KAKAO_LOCAL_REST_API_KEY 또는 --kakao-api-key 가 필요합니다.")
 
-    connection = connect_mysql()
     inserted = 0
     updated = 0
     skipped = 0
+    geocode_failed = 0
     pages_fetched = 0
 
     logger.info(
-        "공공 도서관 적재 시작: page_start=%s, pages=%s, num_rows=%s, filters=%s",
+        "청년센터 적재 시작: page_start=%s, pages=%s, page_size=%s, filters=%s",
         args.page_start,
         "ALL" if args.pages == 0 else args.pages,
-        args.num_rows,
+        args.page_size,
         {key: value for key, value in filters.items() if value},
     )
 
+    connection = connect_mysql()
     try:
         with connection.cursor() as cursor:
-            page_no = args.page_start
+            ensure_study_space_type_enum(cursor, YOUTH_CENTER_TYPE)
+
+            page_num = args.page_start
+            processed_center_ids: set[str] = set()
             while True:
                 if args.pages > 0 and pages_fetched >= args.pages:
                     break
 
                 page = collector.fetch_page(
-                    page_no=page_no,
-                    num_of_rows=args.num_rows,
+                    page_num=page_num,
+                    page_size=args.page_size,
+                    page_type=args.page_type,
                     filters=filters,
                     debug=(pages_fetched == 0),
                 )
                 pages_fetched += 1
 
                 for item in page["items"]:
-                    normalized = normalize_public_library_to_study_space(item)
+                    center_id = (item.get("cntrSn") or "").strip()
+                    if center_id and center_id in processed_center_ids:
+                        continue
+
+                    geocoded = geocoder.geocode(
+                        build_center_address(item) or item.get("cntrAddr", ""),
+                        keyword=item.get("cntrNm", ""),
+                    )
+                    if geocoded is None:
+                        geocode_failed += 1
+                        skipped += 1
+                        logger.warning("[청년센터] 좌표 변환 실패로 스킵: %s", item.get("cntrNm"))
+                        continue
+
+                    lat, lng = geocoded
+                    normalized = normalize_youth_center_to_study_space(item, latitude=lat, longitude=lng)
                     if normalized is None:
                         skipped += 1
                         continue
 
                     action = upsert_study_space(cursor, normalized)
+                    if center_id:
+                        processed_center_ids.add(center_id)
                     if action == "inserted":
                         inserted += 1
                     else:
@@ -194,20 +251,21 @@ def main() -> None:
                     break
 
                 total_count = page["totalCount"]
-                expected_count = page["pageNo"] * page["numOfRows"]
+                expected_count = page["pageNum"] * page["pageSize"]
                 if total_count and expected_count >= total_count:
                     break
 
-                page_no += 1
+                page_num += 1
                 collector.delay()
 
         connection.commit()
         logger.info(
-            "study_spaces 적재 완료: pages_fetched=%s inserted=%s updated=%s skipped=%s",
+            "청년센터 적재 완료: pages_fetched=%s inserted=%s updated=%s skipped=%s geocode_failed=%s",
             pages_fetched,
             inserted,
             updated,
             skipped,
+            geocode_failed,
         )
     except Exception:
         connection.rollback()

--- a/space_geocoders.py
+++ b/space_geocoders.py
@@ -1,0 +1,137 @@
+import logging
+import os
+import re
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class KakaoLocalGeocoder:
+    ADDRESS_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/address.json"
+    KEYWORD_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/keyword.json"
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.getenv("KAKAO_LOCAL_REST_API_KEY") or os.getenv("KAKAO_REST_API_KEY")
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": "KuriqDataPipeline/1.0"})
+        self._cache: dict[str, tuple[float, float] | None] = {}
+
+    def geocode(self, address: str, keyword: str | None = None) -> tuple[float, float] | None:
+        normalized = (address or "").strip()
+        if not normalized:
+            return None
+
+        if normalized in self._cache:
+            return self._cache[normalized]
+
+        if not self.api_key:
+            raise RuntimeError("KAKAO_LOCAL_REST_API_KEY 또는 KAKAO_REST_API_KEY 환경 변수가 필요합니다.")
+
+        candidates = self._build_address_candidates(normalized)
+
+        for candidate in candidates:
+            try:
+                response = self.session.get(
+                    self.ADDRESS_SEARCH_URL,
+                    params={"query": candidate},
+                    headers={"Authorization": f"KakaoAK {self.api_key}"},
+                    timeout=(10, 30),
+                )
+                response.raise_for_status()
+                payload = response.json()
+                documents = payload.get("documents") or []
+                if not documents:
+                    continue
+
+                first: dict[str, Any] = documents[0]
+                lng = float(first["x"])
+                lat = float(first["y"])
+                self._cache[normalized] = (lat, lng)
+                return lat, lng
+            except Exception as e:
+                logger.warning("[KakaoLocalGeocoder] 주소 변환 실패: %s (%s)", candidate, e)
+
+        keyword_candidates = self._build_keyword_candidates(keyword, normalized)
+        for candidate in keyword_candidates:
+            try:
+                response = self.session.get(
+                    self.KEYWORD_SEARCH_URL,
+                    params={"query": candidate, "size": 5},
+                    headers={"Authorization": f"KakaoAK {self.api_key}"},
+                    timeout=(10, 30),
+                )
+                response.raise_for_status()
+                payload = response.json()
+                documents = payload.get("documents") or []
+                if not documents:
+                    continue
+
+                first: dict[str, Any] = documents[0]
+                lng = float(first["x"])
+                lat = float(first["y"])
+                self._cache[normalized] = (lat, lng)
+                return lat, lng
+            except Exception as e:
+                logger.warning("[KakaoLocalGeocoder] 키워드 변환 실패: %s (%s)", candidate, e)
+
+        self._cache[normalized] = None
+        return None
+
+    @staticmethod
+    def _clean_text(value: str) -> str:
+        cleaned = (value or "").strip()
+        cleaned = cleaned.replace("대전광약시", "대전광역시")
+        cleaned = cleaned.replace("백룡료", "백룡로")
+        cleaned = re.sub(r"(적금로)(\d+)", r"\1 \2", cleaned)
+        cleaned = re.sub(r"\([^)]*\)", " ", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        return cleaned.strip(" ,")
+
+    @classmethod
+    def _build_address_candidates(cls, address: str) -> list[str]:
+        cleaned = cls._clean_text(address)
+        variants = [cleaned]
+
+        if " " in cleaned:
+            variants.append(re.sub(r"\b\d+[~\-/]?\d*층\b", "", cleaned).strip(" ,"))
+            variants.append(re.sub(r"\b[0-9]+층\b", "", cleaned).strip(" ,"))
+
+        road_addr_match = re.search(r"^(.*?\S\s\d+(?:-\d+)?)\b", cleaned)
+        if road_addr_match:
+            variants.append(road_addr_match.group(1).strip(" ,"))
+
+        if "(" in address:
+            variants.append(cls._clean_text(address.split("(", 1)[0]))
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for candidate in variants:
+            candidate = re.sub(r"\s+", " ", candidate).strip(" ,")
+            if candidate and candidate not in seen:
+                deduped.append(candidate)
+                seen.add(candidate)
+        return deduped
+
+    @classmethod
+    def _build_keyword_candidates(cls, keyword: str | None, address: str) -> list[str]:
+        candidates = []
+        if keyword:
+            cleaned_keyword = cls._clean_text(keyword)
+            candidates.append(cleaned_keyword)
+            candidates.append(cleaned_keyword.replace("²¹", "21"))
+
+        cleaned_address = cls._clean_text(address)
+        tokens = cleaned_address.split()
+        if len(tokens) >= 2 and keyword:
+            candidates.append(f"{tokens[0]} {tokens[1]} {cls._clean_text(keyword)}")
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            candidate = candidate.strip()
+            if candidate and candidate not in seen:
+                deduped.append(candidate)
+                seen.add(candidate)
+        return deduped

--- a/space_normalizers.py
+++ b/space_normalizers.py
@@ -69,3 +69,27 @@ def normalize_public_library_to_study_space(item: dict) -> StudySpaceRecord | No
         is_active=True,
         last_updated_at=_parse_date(_pick(item, "referenceDate", "REFERENCE_DATE")),
     )
+
+
+def normalize_youth_center_to_study_space(item: dict, latitude: float, longitude: float) -> StudySpaceRecord | None:
+    name = _pick(item, "cntrNm", "CNTR_NM")
+    address = _pick(item, "cntrAddr", "CNTR_ADDR")
+    detail_address = _pick(item, "cntrDaddr", "CNTR_DADDR")
+    full_address = " ".join(part.strip() for part in [address, detail_address] if part and part.strip())
+
+    if not name or not full_address:
+        return None
+
+    return StudySpaceRecord(
+        name=name,
+        type="YOUTH_CENTER",
+        address=full_address,
+        latitude=StudySpaceRecord.quantize_coordinate(latitude),
+        longitude=StudySpaceRecord.quantize_coordinate(longitude),
+        operating_hours=None,
+        phone=_pick(item, "cntrTelno", "CNTR_TELNO"),
+        has_wifi=False,
+        has_power_outlet=False,
+        is_active=True,
+        last_updated_at=None,
+    )


### PR DESCRIPTION
## 요약
- 공공도서관 적재 스크립트를 운영 환경에서 다시 돌리기 쉽게 정리하고, 재시도와 타임아웃 처리도 함께 보완했습니다.
- 청년센터 수집기와 적재 스크립트를 추가해 study_spaces에 청년센터 데이터를 함께 적재할 수 있게 했습니다.
- 주소 정제와 지오코딩 보조 로직을 넣어 누락되는 좌표를 줄이고, 실행 방법을 README에 정리했습니다.

## 확인한 것
- python3 -m py_compile collectors/base.py collectors/youth_center.py load_public_libraries_to_mysql.py load_youth_centers_to_mysql.py space_geocoders.py space_normalizers.py